### PR TITLE
Fix issue where prepared statement can only be used once

### DIFF
--- a/cpp/bridge.cpp
+++ b/cpp/bridge.cpp
@@ -181,8 +181,6 @@ BridgeResult opsqlite_execute_prepared_statement(
 
   check_db_open(dbName);
 
-  sqlite3_reset(statement);
-
   sqlite3 *db = dbMap[dbName];
 
   const char *errorMessage;
@@ -295,6 +293,8 @@ BridgeResult opsqlite_execute_prepared_statement(
       isConsuming = false;
     }
   }
+
+  sqlite3_reset(statement);
 
   if (isFailed) {
 


### PR DESCRIPTION
Move `sqlite3_reset` call after `sqlite3_step` in `opsqlite_execute_prepared_statement`

Fixes issue where new data does not correctly bind to a prepared statement after the first execution when inserting records, causing an unique constraint exception:

> Error: Exception in HostFunction: [op-sqlite] SQLite code: 19 execution error: UNIQUE constraint failed: mytable.id